### PR TITLE
게시판 api 만들기 - Data REST 적용 및 테스트 정의

### DIFF
--- a/spring-project-board/build.gradle
+++ b/spring-project-board/build.gradle
@@ -22,6 +22,8 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-data-rest'
+    implementation 'org.springframework.data:spring-data-rest-hal-explorer'
     runtimeOnly 'com.h2database:h2'
     runtimeOnly 'com.mysql:mysql-connector-j'
     compileOnly 'org.projectlombok:lombok'

--- a/spring-project-board/src/main/java/com/shinny/projectboard/repository/ArticleCommentRepository.java
+++ b/spring-project-board/src/main/java/com/shinny/projectboard/repository/ArticleCommentRepository.java
@@ -2,6 +2,8 @@ package com.shinny.projectboard.repository;
 
 import com.shinny.projectboard.domain.ArticleComment;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.rest.core.annotation.RepositoryRestResource;
 
+@RepositoryRestResource
 public interface ArticleCommentRepository extends JpaRepository<ArticleComment, Long> {
 }

--- a/spring-project-board/src/main/java/com/shinny/projectboard/repository/ArticleRepository.java
+++ b/spring-project-board/src/main/java/com/shinny/projectboard/repository/ArticleRepository.java
@@ -2,6 +2,9 @@ package com.shinny.projectboard.repository;
 
 import com.shinny.projectboard.domain.Article;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.rest.core.annotation.RepositoryRestResource;
+
+@RepositoryRestResource
 public interface ArticleRepository extends JpaRepository<Article, Long> {
 
 }

--- a/spring-project-board/src/main/resources/application.yaml
+++ b/spring-project-board/src/main/resources/application.yaml
@@ -25,6 +25,10 @@ spring:
       hibernate.format_sql: true
       hibernate.default_batch_fetch_size: 100 # 연관 관계가 맵핑되어 있는 한 번에 벌크로 select 할 수 있게 해줌.
   sql.init.mode: always
+  data:
+    rest:
+      base-path: /api
+      detection-strategy: annotated
 
 
 

--- a/spring-project-board/src/test/java/com/shinny/projectboard/controller/DataRestTest.java
+++ b/spring-project-board/src/test/java/com/shinny/projectboard/controller/DataRestTest.java
@@ -1,0 +1,85 @@
+package com.shinny.projectboard.controller;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@DisplayName("Data REST TEST")
+@Transactional // 테스트에 붙은 Transactional 은 rollback 이 기본값
+@AutoConfigureMockMvc
+@SpringBootTest
+public class DataRestTest {
+
+    private final MockMvc mvc;
+
+    public DataRestTest(@Autowired MockMvc mvc) {
+        this.mvc = mvc;
+    }
+
+    @DisplayName("[api] 게시글 리스트 조회")
+    @Test
+    void givenNothing_whenRequestingArticles_thenReturnArticlesJsonResponse() throws Exception {
+        // Given
+        // When
+        mvc.perform(get("/api/articles"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.valueOf("application/hal+json")));
+        // Then
+    }
+
+    @DisplayName("[api] 게시글 단건 조회")
+    @Test
+    void givenNothing_whenRequestingArticle_thenReturnArticleJsonResponse() throws Exception {
+        // Given
+        // When
+        mvc.perform(get("/api/articles/1"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.valueOf("application/hal+json")));
+        // Then
+    }
+
+    @DisplayName("[api] 게시글 -> 댓글 리스트 조회")
+    @Test
+    public void givenNothing_whenRequestingArticleCommentsFromArticle_thenReturnsArticleCommentsJsonResponse() throws Exception{
+        // given
+
+        // when
+        mvc.perform(get("/api/articles/1/articleComments"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.valueOf("application/hal+json")));
+        // then
+     }
+
+    @DisplayName("[api] 댓글 리스트 조회")
+    @Test
+    public void givenNothing_whenRequestingArticleComments_thenReturnsArticleCommentsJsonResponse() throws Exception{
+        // given
+
+        // when
+        mvc.perform(get("/api/articleComments"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.valueOf("application/hal+json")));
+        // then
+    }
+
+    @DisplayName("[api] 댓글 단건 조회")
+    @Test
+    public void givenNothing_whenRequestingArticleComment_thenReturnsArticleCommentsJsonResponse() throws Exception{
+        // given
+
+        // when
+        mvc.perform(get("/api/articleComments/1"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.valueOf("application/hal+json")));
+        // then
+    }
+}


### PR DESCRIPTION
게시글, 댓글 데이터는 간편하게 Spring Data REST 로 서비스하고, 해당 api 들의 존재 여부만 체크하도록 통합테스트 작성